### PR TITLE
Adding ability to disable quality option.

### DIFF
--- a/lib/rtsp-ffmpeg.js
+++ b/lib/rtsp-ffmpeg.js
@@ -25,7 +25,7 @@ var FFMpeg = function(options) {
 	}
 	this.rate = options.rate || 10;
 	this.resolution = options.resolution;
-	this.quality = options.quality || '3';
+	this.quality = (options.quality === undefined || options.quality === "") ? 3 : options.quality;
 	this.arguments = options.arguments || [];
 
 	this.on('newListener', newListener.bind(this));
@@ -67,14 +67,16 @@ FFMpeg.prototype._args = function() {
 	return this.arguments.concat([
 		'-loglevel', 'quiet'
 		, '-i', this.input
-		, '-r', this.rate.toString()
+		, '-r', this.rate.toString()]
+		, this.quality ? ['-q:v', this.quality.toString()] : [],
+	[
 		//, '-vf', 'fps=25'
-		, '-q:v', this.quality.toString()
 		//, '-b:v', '32k'
-		, '-f', 'image2'
+		'-f', 'image2'
 		, '-updatefirst', '1'
 		, '-'
-	], this.resolution ? ['-s', this.resolution] : []);
+	]
+	, this.resolution ? ['-s', this.resolution] : []);
 };
 
 /**


### PR DESCRIPTION
Ability to disable quality ffmpeg option.

Fix issue 9 : https://github.com/agsh/rtsp-ffmpeg/issues/9

Some systems does not support this option (quality) and can display cropped image. In order to disable quality you should set quality option to false (ex : new rtsp.FFMpeg({input: uri, resolution: '1280x720', quality:false, rate:10});)

If quality option is not set, it will be set by default at 3 (like previously)