### PR TITLE
Update rtsp-ffmpeg

### DIFF
--- a/lib/rtsp-ffmpeg.js
+++ b/lib/rtsp-ffmpeg.js
@@ -5,6 +5,7 @@
 const spawn = require('child_process').spawn
 	, EventEmitter = require('events').EventEmitter
 	, util = require('util')
+	, Buffer = require('buffer').Buffer
 	;
 
 /**
@@ -27,7 +28,7 @@ var FFMpeg = function(options) {
 	this.resolution = options.resolution;
 	this.quality = (options.quality === undefined || options.quality === "") ? 3 : options.quality;
 	this.arguments = options.arguments || [];
-	this.imageData = []; // Store the entire data image into this variable. This attribute is replaced each time a full image is received from the stream.
+	this.buff = new Buffer(''); // Store the entire data image into this variable. This attribute is replaced each time a full image is received from the stream.
 
 	this.on('newListener', newListener.bind(this));
 	this.on('removeListener', removeListener.bind(this));
@@ -87,21 +88,19 @@ FFMpeg.prototype.start = function() {
 	var self = this;
 	this.child = spawn(FFMpeg.cmd, this._args());
 	this.child.stdout.on('data', function(data){
-		//The image can be composed of one or multiple chunk when receiving stream data.
-		//Store all bytes into an array until we meet flag "FF D9" that mean it's the end of the image then we can send all data in order to display the full image.
-		for(var idx = 0; idx < data.length-1;idx++){
-			offset = data[idx].toString(16);
-			offset2 = data[idx+1].toString(16);
+	//The image can be composed of one or multiple chunk when receiving stream data.
+	//Store all bytes into an array until we meet flag "FF D9" that mean it's the end of the image then we can send all data in order to display the full image.
+	if (data.length >1) {
+            self.buff = Buffer.concat([self.buff, data]);
 
-			if(offset == "ff" && offset2 == "d9"){
-				self.imageData.push(data[idx]);
-				self.imageData.push(data[idx+1]);
-				self.emit('data', Buffer.from(self.imageData));
-				self.imageData = [];
-			}else{
-				self.imageData.push(data[idx]);
-			}
-		}
+            offset      = data[data.length-2].toString(16);
+            offset2     = data[data.length-1].toString(16);
+
+            if(offset == "ff" && offset2 == "d9") {
+                self.emit('data', self.buff);
+                self.buff = new Buffer('');
+            }
+	}
 	});
 	this.child.stderr.on('data', function(data) {
 		throw new Error(data);


### PR DESCRIPTION
Changes for removing image corruptions when concat data.

_Note:_
In real project, I use:
`self.emit('data', self.buff.toString('base64'));`
for exclude base64ArrayBuffer function on a client