### PR TITLE
Security patch of rtsp-ffmpeg.js

### DIFF
--- a/lib/rtsp-ffmpeg.js
+++ b/lib/rtsp-ffmpeg.js
@@ -28,7 +28,7 @@ var FFMpeg = function(options) {
 	this.resolution = options.resolution;
 	this.quality = (options.quality === undefined || options.quality === "") ? 3 : options.quality;
 	this.arguments = options.arguments || [];
-	this.buff = new Buffer(''); // Store the entire data image into this variable. This attribute is replaced each time a full image is received from the stream.
+	this.buff = Buffer.from(''); // Store the entire data image into this variable. This attribute is replaced each time a full image is received from the stream.
 
 	this.on('newListener', newListener.bind(this));
 	this.on('removeListener', removeListener.bind(this));
@@ -98,7 +98,7 @@ FFMpeg.prototype.start = function() {
 
             if(offset == "ff" && offset2 == "d9") {
                 self.emit('data', self.buff);
-                self.buff = new Buffer('');
+                self.buff = Buffer.from('');
             }
 	}
 	});


### PR DESCRIPTION
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.