### PR TITLE
Prevent NPE if a child is already dead

### DIFF
--- a/lib/rtsp-ffmpeg.js
+++ b/lib/rtsp-ffmpeg.js
@@ -125,7 +125,9 @@ FFMpeg.prototype.start = function() {
  * Stop ffmpeg spawn process
  */
 FFMpeg.prototype.stop = function() {
-	this.child.kill();
+	if (this.child) {
+		this.child.kill();
+	}
 	delete this.child;
 	this.emit('stop');
 };


### PR DESCRIPTION
Sometimes a child process dies earlier than the `data` listener gets disconnected. It may happen because of FFmpeg internal problems, or because of the network connection problems.

Before this change, disconnecting from a dead FFmpeg stream caused the following JS error:

```
app_1         | TypeError: Cannot read property 'kill' of undefined
app_1         |     at FFMpeg.stop (/app/node_modules/rtsp-ffmpeg/lib/rtsp-ffmpeg.js:128:13)
app_1         |     at FFMpeg.removeListener (/app/node_modules/rtsp-ffmpeg/lib/rtsp-ffmpeg.js:56:8)
app_1         |     at FFMpeg.emit (events.js:315:20)
app_1         |     at FFMpeg.EventEmitter.emit (domain.js:467:12)
app_1         |     at FFMpeg.removeListener (events.js:468:18)
```